### PR TITLE
ci(github-actions): Limit Claude code review to first submission

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,17 +2,18 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]  # Only run automatically when PR is first created
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
+  workflow_dispatch:  # Allow manual triggering from GitHub UI
 
 jobs:
   claude-review:
-    if: github.event.pull_request.user.login == 'mattjmcnaughton'
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.user.login == 'mattjmcnaughton'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Update Claude Code Review workflow to:
- Run automatically only when PR is first opened (removed 'synchronize' trigger)
- Allow manual triggering via workflow_dispatch from GitHub UI
- Update condition to handle both automatic and manual trigger modes

This prevents automatic review on every push while still allowing manual reviews when needed.