### PR TITLE
docs: expand agent collaboration guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,17 @@
-# Claude Code Development Guidelines
+# Autonomous Coding Agent Guidelines
 
-This document contains guidance for Claude Code when working on this project.
+This document contains guidance for any code-generation agent collaborating on this project.
+
+Please also review the repository documentation for additional context:
+- [README.md](README.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- Additional references in the `docs/` directory
+
+## Commit Messages
+
+Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for all commit messages.
+Example conventional commit: `feat: add dataset summary command`.
+Keep commit bodies concise and focused on what changed and why.
 
 ## Testing
 
@@ -11,6 +22,12 @@ just test
 ```
 
 Do NOT run pytest directly. The justfile ensures proper configuration and environment setup.
+
+## Pull Requests
+
+- Keep changes tightly scoped; split work into separate PRs when needed.
+- Summarize modifications and corresponding tests in the final hand-off message.
+- Reference relevant issues or tickets in the PR description when applicable.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- point agents to additional documentation in the docs directory
- reinforce expectations around concise commit bodies
- outline pull request hygiene and final hand-off requirements for agents

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176f05f9408332b5e9e733b436e519)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generalizes and expands CLAUDE.md into an agent-wide guide with commit/PR guidance, and links it from AGENTS.md.
> 
> - **Docs**:
>   - `CLAUDE.md`:
>     - Retitled and generalized for all coding agents.
>     - Adds links to `README.md`, `CONTRIBUTING.md`, and `docs/` references.
>     - Introduces Conventional Commits guidance and concise commit body expectations.
>     - Adds PR hygiene and final hand-off requirements.
>     - Reiterates testing via `just test`; preserves project structure, code patterns, dataset splits, and workflow sections.
>   - `AGENTS.md`: Points to `CLAUDE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ca748e7cc2cb667bafe259afad452fb1fb7e414. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->